### PR TITLE
Add initial Gradle build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 /classes/
+bin/
+build/
+.gradle
+gradle-app.setting
+!gradle-wrapper.jar
+.gradletasknamecache

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,47 @@
+apply plugin: 'java'
+apply plugin: 'maven'
+apply plugin: 'maven-publish'
+
+group = 'com.dorkbox'
+version = '3.13-SNAPSHOT'
+description = """Dorkbox-SystemTray"""
+
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+tasks.withType(JavaCompile) { options.encoding = 'UTF-8' }
+
+sourceSets {
+	main {
+		java { srcDirs = ['src'] }
+	}
+	test {
+		java { srcDirs = ['test'] }
+	}
+}
+
+
+publishing {
+	publications {
+		maven(MavenPublication) {
+			artifactId 'SystemTray'
+			from components.java
+		}
+	}
+}
+
+repositories {
+	mavenLocal()
+	maven { url "http://repo.maven.apache.org/maven2" }
+	maven { url "http://cfmlprojects.org/artifacts" }
+}
+
+dependencies {
+	compile group: 'com.dorkbox', name: 'ShellExecutor', version:'1.1'
+	compile('com.dorkbox:Utilities:2.21-SNAPSHOT') {  transitive = false  }
+	compile group: 'ch.qos.logback', name: 'logback-classic', version:'1.1.6'
+	compileOnly group: 'org.eclipse.swt', name: 'org.eclipse.swt.gtk.linux.x86_64', version:'4.3'
+	compile group: 'org.javassist', name: 'javassist', version:'3.21.0-GA'
+	compile group: 'net.java.dev.jna', name: 'jna', version:'4.3.0'
+	compile group: 'net.java.dev.jna', name: 'jna-platform', version:'4.3.0'
+	runtime group: 'org.slf4j', name: 'slf4j-api', version:'1.7.25'
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'Dorkbox-SystemTray'


### PR DESCRIPTION
I've got one for the Utilities too, but that's going to need some input... @dorkbox do you have a script for making that like you did for this?  Seems like you split it out into sub-utilities (heh) somehow?  Gradle can do that easily too, just need to know what goes where.  Here's an initial go tho.  Refs #81 

FWIW, I'm really liking using a git-tag based versioning setup, with that it's a -SNAPSHOT until tagged so you don't have to keep modifying the sources just to set a version (and it has the number of commits different and whatnot thus kinda useful to measure change).