### PR TITLE
Updated icon size detection for better quality icons with AppIndicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ Ubuntu 22.04 | ✓ |
  | |
 UbuntuGnome 16.04 | ✓ |
 UbuntuGnome 17.04 | ✓ |
+| |
+Kubuntu 23.10 | ✓ |
  | |
 XUbuntu 16.04 | ✓ |
  | |

--- a/src/dorkbox/systemTray/util/GtkTheme.java
+++ b/src/dorkbox/systemTray/util/GtkTheme.java
@@ -375,27 +375,25 @@ class GtkTheme {
                             }
                         }
                     }
+                }
+            }
+            
+            // The following is a bit ugly, but these are the defaults for KDE-plasma
+            String plasmaVersion = OS.DesktopEnv.INSTANCE.getPlasmaVersionFull();
+            if (plasmaVersion != null) {
+                // this shouldn't ever happen, because we have the KDE config file!
 
-                    // if we have the file, but DO NOT have the 'iconSize' entry -- then we are guessing.
+                String[] versionParts = plasmaVersion.split("\\.");
+                int majorVersion = Integer.parseInt(versionParts[0]);
+                int minorVersion = Integer.parseInt(versionParts[1]);
+                if (majorVersion < 5 || (majorVersion == 5 && minorVersion < 5)) {
+                    // older versions use GtkStatusIcon
+                    return 22;
+                } else {
+                    // newer versions use appindicator, but the user MIGHT have to install libappindicator
 
-                    // The following is a bit ugly, but are the defaults for KDE-plasma
-                    String plasmaVersion = OS.DesktopEnv.INSTANCE.getPlasmaVersionFull();
-                    if (plasmaVersion != null) {
-                        // this shouldn't ever happen, because we have the KDE config file!
-
-                        String[] versionParts = plasmaVersion.split("\\.");
-                        int majorVersion = Integer.parseInt(versionParts[0]);
-                        int minorVersion = Integer.parseInt(versionParts[1]);
-                        if (majorVersion < 5 || (majorVersion == 5 && minorVersion < 5)) {
-                            // older versions use GtkStatusIcon
-                            return 22;
-                        } else {
-                            // newer versions use appindicator, but the user MIGHT have to install libappindicator
-
-                            // 128 is the max size possible, and it will AUTOMATICALLY scale down as necessary.
-                            return 128;
-                        }
-                    }
+                    // 128 is the max size possible, and it will AUTOMATICALLY scale down as necessary.
+                    return 128;
                 }
             }
         }


### PR DESCRIPTION
This PR definitely fixes an issue for me, but you certainly have more experience with this so maybe you have a better solution.

AppIndicator looks to be accepting tray icons of arbitrary size, and in my testing icons of size 64x64 work great.
Unfortunately `getTrayImageSize()` returns 24 for me and this results in an ugly downscaled icon. I have modified it so that if AppIndicator is used, it returns 64, which yields a much better result.

To do this I had to add the tray type as an argument to `getTrayImageSize`, and to do that I had to do some refactoring around how tray type is passed around. I removed the `isTrayType` method operating on the `Class` values and added `getTrayType` that executes once and returns the enum, so that the enum can be easily compared instead.