### PR TITLE
Added a try-catch for LinkageError on macOS

### DIFF
--- a/src/dorkbox/systemTray/util/SystemTrayFixesMacOS.java
+++ b/src/dorkbox/systemTray/util/SystemTrayFixesMacOS.java
@@ -101,12 +101,14 @@ class SystemTrayFixesMacOS {
 
         try {
             {
-                {
+                try {
                     // have to make the peer field public
                     CtClass trayIconClass = pool.get("java.awt.TrayIcon");
                     CtField peer = trayIconClass.getField("peer");
                     peer.setModifiers(peer.getModifiers() & Modifier.PUBLIC);
                     ClassUtils.defineClass(null, trayIconClass.toBytecode());
+                } catch (LinkageError e) {
+                    logger.error("Linkage error making the java.awt.TrayIcon peer field public.", e);
                 }
 
                 CtClass trayClass = pool.get("sun.lwawt.macosx.CTrayIcon");


### PR DESCRIPTION
On macOS I am getting a `LinkageError` crash in `SystemTrayFixesMacOS.java`.
Also reported here: https://github.com/JetBrains/compose-multiplatform/issues/1847#issuecomment-1768969611

Catching the issue prevents the crash and allows the rest of the fixes to still work correctly: menu item icons are set correctly and the menu works fine. The functionality to enable right-click (in additional to left click which works as normal) to open the tray menu does not apply in this case, but tray icons on macOS normally don't open their menu when right-clicked, so this results in normal behaviour anyway.
